### PR TITLE
Add jshint.cached()

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ Adds the following properties to the file object:
   file.jshint.opt = {}; // The options you passed to JSHint
 ```
 
+## Caching
+
+Optionally, you can use the `jshint.cached(...)` method to cache previously linted files.  It takes the same options as `jshint(...)` but caches successful files so they aren't ran again unless they change.
+
+This method uses a small temp file cache based on a hash of the contents of the file, the JSHint version and the JSHint options passed in.  If a JSHint option is changed all files will be ran again to prevent false positives.
+
+```javascript
+var jshint = require('gulp-jshint');
+
+gulp.task('lint', function() {
+  gulp.src('./lib/*.js')
+    .pipe(jshint.cached())
+    .pipe(jshint.reporter('YOUR_REPORTER_HERE'));
+});
+```
+
 ## Reporters
 
 ### JSHint reporters

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "map-stream": "~0.0.4",
     "jshint": "~2.4.0",
-    "gulp-util": "~2.2.5"
+    "gulp-util": "~2.2.5",
+    "gulp-cache": "0.0.4"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test/caching.js
+++ b/test/caching.js
@@ -1,0 +1,56 @@
+var jshint = require('../');
+var should = require('should');
+var gutil = require('gulp-util');
+var path = require('path');
+require('mocha');
+
+describe('gulp-jshint', function() {
+  beforeEach(function (done) {
+    // Clear all previously cached successes
+    jshint.cached.fileCache.clear(null, done);
+  });
+
+  describe('jshint.cached()', function() {
+    it('should cache previously linted files', function (done) {
+      var a = 0;
+
+      var fakeFile = new gutil.File({
+        path: './test/fixture/file.js',
+        cwd: './test/',
+        base: './test/fixture/',
+        contents: new Buffer('wadup();')
+      });
+
+      var stream = jshint.cached({});
+
+      stream.once('data', function(newFile){
+        should.exist(newFile.jshint);
+        should.not.exist(newFile.jshint.cached);
+
+        newFile.jshint.success.should.equal(true);
+
+        stream.once('data', function(newFile) {
+            should.exist(newFile.jshint);
+            newFile.jshint.success.should.equal(true);
+            
+            should.exist(newFile.jshint.cached);
+            newFile.jshint.cached.should.equal(true);
+
+            ++a;
+        });
+
+        ++a;
+        stream.write(fakeFile);
+        stream.end();
+      });
+
+      stream.once('end', function () {
+        a.should.equal(2);
+        done();
+      });
+
+      stream.write(fakeFile);
+    });
+  });
+
+});


### PR DESCRIPTION
- Introduces a dependency to [gulp-cache](https://github.com/jgable/gulp-cache)
- Adds a jshint.cached() method that caches successfully linted files by
  contents, jshint version and jshint options
- Exposes the file cache used as jshint.cached.fileCache for manipulation (including clearing).
- Very basic unit test to confirm caching
