### PR TITLE
Change node engine to 11 from 12 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
   - "0.9"
   - "0.10"
-  - "0.12"
+  - "0.11"


### PR DESCRIPTION
There is no 12 version so Travis is falling back to 0.10.*.  

More info in the [build log](https://travis-ci.org/wearefractal/gulp-jshint/jobs/16297642#L15).
