### PR TITLE
add gulp var to example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 
 ```javascript
 var jshint = require('gulp-jshint');
+var gulp   = require('gulp');
 
 gulp.task('lint', function() {
   gulp.src('./lib/*.js')


### PR DESCRIPTION
Add `gulp` variable to example in README.
