### PR TITLE
Update JSHint to v2.5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "map-stream": "0.0.4",
-    "jshint": "^2.4.4",
+    "jshint": "^2.5.0",
     "gulp-util": "~2.2.5",
     "rcloader": "^0.1.2",
     "minimatch": "^0.2.14",


### PR DESCRIPTION
[JSHint](https://github.com/jshint/jshint/) v2.5.0 has been released.
