### PR TITLE
Return stream in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var jshint = require('gulp-jshint');
 var gulp   = require('gulp');
 
 gulp.task('lint', function() {
-  gulp.src('./lib/*.js')
+  return gulp.src('./lib/*.js')
     .pipe(jshint())
     .pipe(jshint.reporter('YOUR_REPORTER_HERE'));
 });
@@ -127,7 +127,7 @@ var myReporter = map(function (file, cb) {
 });
 
 gulp.task('lint', function() {
-  gulp.files('./lib/*.js')
+  return gulp.files('./lib/*.js')
     .pipe(jshint())
     .pipe(myReporter);
 });


### PR DESCRIPTION
Examples return the stream of processed files so gulp treats the task as asynchronous and wait for it to complete before reporting so: plugin duration is relevant and errors are displayed before the plugin is marked as completed.
