### PR TITLE
Remove potential Unicode BOM

### DIFF
--- a/src/lint.js
+++ b/src/lint.js
@@ -59,6 +59,7 @@ module.exports = function createLintFunction(userOpts) {
       // get or create file.jshint, we will write all output here
       var out = file.jshint || (file.jshint = {});
       var str = (out.extracted) || file.contents.toString('utf8');
+      str = str.replace(/^\uFEFF/, '');
 
       out.success = jshint(str, cfg, globals);
       if (!out.success) reportErrors(file, out, cfg);


### PR DESCRIPTION
This pull request strips potential unicode BOM from the files before passing it to jshint as jshint cli does ([link to code](https://github.com/jshint/jshint/blob/master/src/cli.js#L483)) and as suggested by nodejs developers ([link](https://github.com/joyent/node/issues/1918)). This is needed because some text editors insist on setting the BOM (e.g. Visual Studio).
