### PR TITLE
Update JSHint to latest version (2.5.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "jshint": "^2.5.0",
+    "jshint": "^2.5.6",
     "lodash": "^2.4.1",
     "minimatch": "^1.0.0",
     "rcloader": "^0.1.2",


### PR DESCRIPTION
Per #79 

Current: 2.5.0 (April-ish)
Latest: 2.5.6 (11 days ago)

A few Harmony options were added that are necessary for my project.
