### PR TITLE
Add instantly failing reporter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ var jshintPlugin = function (opt) {
 
 // expose the reporters
 jshintPlugin.failReporter = reporters.fail;
+jshintPlugin.instafailReporter = reporters.instafail;
 jshintPlugin.loadReporter = reporters.loadReporter;
 jshintPlugin.reporter = reporters.reporter;
 

--- a/src/reporters/index.js
+++ b/src/reporters/index.js
@@ -2,7 +2,8 @@ var PluginError = require('gulp-util').PluginError;
 var stream = require('../stream');
 var _ = require('lodash');
 
-exports.failReporter = require('./fail');
+exports.fail = require('./fail');
+exports.instafail = require('./instafail');
 
 exports.loadReporter = function (reporter) {
   // we want the function
@@ -30,7 +31,7 @@ exports.reporter = function (reporter, reporterCfg) {
   reporterCfg = reporterCfg || {};
 
   if (reporter === 'fail') {
-    return exports.failReporter(reporterCfg);
+    return exports.fail(reporterCfg);
   }
 
   var rpt = exports.loadReporter(reporter || 'default');

--- a/src/reporters/instafail.js
+++ b/src/reporters/instafail.js
@@ -1,0 +1,13 @@
+var stream = require('../stream');
+
+module.exports = function () {
+  return stream(
+    function through(file) {
+      if (file.jshint && !file.jshint.success && !file.jshint.ignored) {
+        process.exit(1);
+      }
+    },
+    function flush() {
+    }
+  );
+};


### PR DESCRIPTION
This PR
- adds another reporter which instantly fails after executing jshint.
- fixes `jshint.failReporter` which was undefined before.
- has been provided because of the following caveat:

My gulpfile looks like this:

```
gulp.task("default", ["lint", "test"], function () {});
gulp.task('lint', function () {
  gulp
    .src([ /* sources */ ])
    .pipe(jshint())
    .pipe(jshint.reporter(require("jshint-stylish")))
    .pipe(jshint.failReporter());
});

gulp.task("test", function () {
  gulp
    .src(path.resolve(__dirname, "test", "**", "*.test.js"), { read: false })
    .pipe(mocha());
});
```

When I have a linting issue and run the default task, it results in this:

```
npm test

> sequelize-cli@0.3.2 test /Users/sdepold/Projects/sequelize/cli
> gulp

[12:16:41] Using gulpfile ~/Projects/sequelize/cli/gulpfile.js
[12:16:41] Starting 'lint'...
[12:16:41] Finished 'lint' after 15 ms
[12:16:41] Starting 'test'...
[12:16:41] Finished 'test' after 1.5 ms
[12:16:41] Starting 'default'...
[12:16:41] Finished 'default' after 4.44 μs

/Users/sdepold/Projects/sequelize/cli/gulpfile.js
  line 11  col 17  Strings must use doublequote.

  ⚠  1 warning



  [MYSQL] bin/sequelize help
EventEmitter#success|ok is deprecated, please use promise-style instead.
EventEmitter#failure|fail|error is deprecated, please use promise-style instead.
    1) prints the help

  [MYSQL] bin/sequelize h

... some other output from the test task ...

events.js:72
        throw er; // Unhandled 'error' event
```

I have honestly no idea why the test task is actually still executed, but apparently the fail reporter does not kill the process but emits an error event which gets delayed until a certain amount of time passes.

Having instafail in place, it looks like this:

```
//gulpfile:
    .pipe(jshint())
    .pipe(jshint.reporter(require("jshint-stylish")))
    .pipe(jshint.instafailReporter());
```

And the gulp run:

```
npm test

> sequelize-cli@0.3.2 test /Users/sdepold/Projects/sequelize/cli
> gulp

[12:21:09] Using gulpfile ~/Projects/sequelize/cli/gulpfile.js
[12:21:09] Starting 'lint'...
[12:21:09] Finished 'lint' after 17 ms
[12:21:09] Starting 'test'...
[12:21:09] Finished 'test' after 1.59 ms
[12:21:09] Starting 'default'...
[12:21:09] Finished 'default' after 4.36 μs

/Users/sdepold/Projects/sequelize/cli/gulpfile.js
  line 11  col 17  Strings must use doublequote.

  ⚠  1 warning

npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```
