### PR TITLE
Ability to specify alternative jshint implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,31 @@ Plugin options:
   - Default is `true`
   - When `false` do not lookup `.jshintrc` files. See the [JSHint docs](http://www.jshint.com/docs/) for more info.
 
+- `linter`
+  - Default is `"jshint"`
+  - Either the name of a module to use for linting the code or a linting function itself. This enables using an alternate (but jshint compatible) linter like `"jsxhint"`.
+  - Here's an example of passing in a module name:
+
+    ```js
+      gulp.task('lint', function() {
+        return gulp.src('./lib/*.js')
+          .pipe(jshint({ linter: 'some-jshint-module' }))
+          .pipe(...);
+      });
+    ```
+
+  - Here's an example of passing in a linting function:
+
+    ```js
+      gulp.task('lint', function() {
+        return gulp.src('./lib/*.js')
+          // This is available for modules like jshint-jsx, which
+          // expose the normal jshint function as JSHINT and the
+          // jsxhint function as JSXHINT
+          .pipe(jshint({ linter: require('jshint-jsx').JSXHINT }))
+          .pipe(...);
+      });
+    ```
 
 You can pass in any other options and it passes them straight to JSHint. Look at their README for more info. You can also pass in the location of your jshintrc file as a string and it will load options from it.
 

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -4,6 +4,8 @@
     "describe": true,
     "it": true,
     "before": true,
-    "after": true
+    "after": true,
+    "beforeEach": true,
+    "afterEach": true
   }
 }

--- a/test/specs/linting.js
+++ b/test/specs/linting.js
@@ -1,4 +1,5 @@
 var Fixture = require('../util').Fixture;
+var PluginError = require('gulp-util').PluginError;
 var jshint = require('../../src');
 
 describe('linting', function () {
@@ -18,5 +19,79 @@ describe('linting', function () {
     stream.write(new Fixture('undef'));
     stream.write(new Fixture('undef'));
     stream.end();
+  });
+
+  describe('custom linter', function () {
+    var jshintSource;
+    var oldSourceJSHINT;
+    beforeEach(function() {
+      jshintSource = require('jshint');
+      oldSourceJSHINT = jshintSource.JSHINT;
+    });
+    afterEach(function() {
+      jshintSource.JSHINT = oldSourceJSHINT;
+    });
+    it('should allow overriding jshint', function (done) {
+      var count = 0;
+      var stream = jshint({
+        linter: function () {
+          count ++;
+          return true;
+        }
+      });
+
+      stream.once('end', function () {
+        count.should.equal(2);
+        done();
+      });
+
+      stream.resume();
+      stream.write(new Fixture('undef'));
+      stream.write(new Fixture('undef'));
+      stream.end();
+    });
+    it('should accept a require able string to a module with a JSHINT property', function (done) {
+      var count = 0;
+
+      // Mock out the jshint JSHINT function so we can spy on it
+      jshintSource.JSHINT = function () {
+        count ++;
+        return true;
+      };
+
+      var stream = jshint({
+        linter: 'jshint'
+      });
+
+      stream.once('end', function () {
+        count.should.equal(2);
+        done();
+      });
+
+      stream.resume();
+      stream.write(new Fixture('undef'));
+      stream.write(new Fixture('undef'));
+      stream.end();      
+    });
+    it('should error with non-function', function () {
+      var wrapper = function () {
+        jshint({
+          linter: {JSHINT: 'not-a-function'}
+        });
+      };
+      wrapper.should.throw(PluginError);
+    });
+    it('should throw an error if there is the JSHINT property is not a function', function () {
+      // make the JSHINT property on the module undefined,
+      // mimicking a bad package
+      jshintSource.JSHINT = undefined;
+
+      var wrapper = function () {
+        jshint({
+          linter: 'jshint'
+        });
+      };
+      wrapper.should.throw(PluginError);    
+    });
   });
 });


### PR DESCRIPTION
Closes #89. Closes #90.

I patched this because I wanted a nice way to run jsxhint via gulp. [gulp-jsxhint](https://www.npmjs.com/package/gulp-jsxhint) is a stub implementation that's not yet supported and there were a number of issues in here (#55, #89, #90) that suggest this is a desired feature. @jtangelder suggested a particularly clean solution, which is what I implemented here.

The motivation for wanting to actually use jsxhint rather than, as you suggest in #55:

```js
.pipe react()
.pipe jshint()
```

is twofold.

First, the conversion from jsx -> js can mess up the line numbers that jshint spits out when finding warnings.

Second, the conversion from jsx -> js can cause lint errors to exist in js code that didn't exist in jsx code (this is mentioned by @elierotenberg in #55)

I'm more than happy to iterate on this as needed.