### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,5 @@
   "engines": {
     "node": ">= 0.4.0"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/spalger/gulp-jshint/raw/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/