### PR TITLE
Upgrade jshint dependency to ^2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "jshint": "^2.5.6",
+    "jshint": "^2.7.0",
     "lodash": "^3.0.1",
     "minimatch": "^2.0.1",
     "rcloader": "0.1.2",


### PR DESCRIPTION
Tried this on my machine and seems to work just fine, also all `gulp test`'s pass.  Resolves spalger/gulp-jshint#102