### PR TITLE
Add syntax highlighting to readme code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,14 @@ You can pass in any other options and it passes them straight to JSHint. Look at
 
 For example, to load your configuration from your `package.json` exclusively and avoid lookup overhead you can do:
 
-    var packageJSON  = require('./package');
-    var jshintConfig = packageJSON.jshintConfig;
+```js
+  var packageJSON  = require('./package');
+  var jshintConfig = packageJSON.jshintConfig;
 
-    jshintConfig.lookup = false;
+  jshintConfig.lookup = false;
 
-    gulp.src('yo').pipe(jshint(jshintConfig));
+  gulp.src('yo').pipe(jshint(jshintConfig));
+```
 
 ## Results
 

--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ You can pass in any other options and it passes them straight to JSHint. Look at
 For example, to load your configuration from your `package.json` exclusively and avoid lookup overhead you can do:
 
 ```js
-  var packageJSON  = require('./package');
-  var jshintConfig = packageJSON.jshintConfig;
+var packageJSON  = require('./package');
+var jshintConfig = packageJSON.jshintConfig;
 
-  jshintConfig.lookup = false;
+jshintConfig.lookup = false;
 
-  gulp.src('yo').pipe(jshint(jshintConfig));
+gulp.src('yo').pipe(jshint(jshintConfig));
 ```
 
 ## Results


### PR DESCRIPTION
One snippet was missing syntax highlighting.