### PR TITLE
[npm] move jshint to peerDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
+install:
+  - npm install
+  - npm install jshint
+sudo: false
 node_js:
-  # - "0.9"
   - "0.10"
-  - "0.11"
+  - "0.12"
+  - "4.1"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Install
 
-    npm install gulp-jshint --save-dev
+    npm install jshint gulp-jshint --save-dev
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "jshint": "^2.7.0",
     "lodash": "^3.0.1",
     "minimatch": "^2.0.1",
     "rcloader": "0.1.2",
     "through2": "~0.6.1"
+  },
+  "peerDependencies": {
+    "jshint": "2.x"
   },
   "devDependencies": {
     "gulp": "^3.8.10",


### PR DESCRIPTION
Special versions of jshint are currently supported via the [`linter` config option](https://github.com/spalger/gulp-jshint#options), but with this change jshint is something you would install along with gulp-jshint.