### PR TITLE
Upgrade lodash version, fix 'repository' field to correct form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ node_modules
 build
 *.node
 components
-.ideanpm
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 build
 *.node
 components
+.ideanpm

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "description": "JSHint plugin for gulp",
   "version": "2.0.0",
   "homepage": "http://github.com/spalger/gulp-jshint",
-  "repository": "git://github.com/spalger/gulp-jshint.git",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/spalger/gulp-jshint.git"
+  },
   "contributors": [
     "Spencer Alger <email@spalger.com>",
     "Fractal <contact@wearefractal.com> (http://wearefractal.com/)"
@@ -14,7 +17,7 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "lodash": "^3.0.1",
+    "lodash": "^4.12.0",
     "minimatch": "^2.0.1",
     "rcloader": "0.1.2",
     "through2": "~0.6.1"


### PR DESCRIPTION
rcloader is v0.2.1 already, this version passes tests, should it be updated too?