### PR TITLE
Fix issue in extract on zero size files

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -6,6 +6,10 @@ module.exports = function extract(when) {
   when = when || 'auto';
 
   return stream(function (file, cb) {
+	  if (!file.isBuffer()) {
+		  return cb(null, file);
+	  }
+	
     fileIgnored(file, function (err, ignored) {
       if (err) return cb(err);
       if (ignored) return cb(null, file);


### PR DESCRIPTION
Just like issue #49, the extract method needs to check to make sure it does not call the `.toString` method on anything that has a zero length such as directories. Issue was on a Windows box if that makes any difference while testing.

gulpfile.js, `paths.html.input` is a series of nested directories:
```javascript
gulp.task('lint:scripts', function () {
    return gulp.src([paths.scripts.input, paths.html.input])
        .pipe(plumber())
        .pipe(jshint.extract('always'))
        .pipe(jshint())
        .pipe(jshint.reporter(jshintReporter))
        .on('end', jshintReporter.writeFile({
        	format: 'checkstyle',
        	filePath: './dist/reports/checkstyle-js.xml'
        }));
});
```

Stack:
```
      file.jshint.extracted = jshintcli.extract(file.contents.toString('utf8'), when);
                                                             ^

TypeError: Cannot read property 'toString' of null
    at C:\data\workspace\eclipse\my-nipr\node_modules\gulp-jshint\src\extract.js:15:62
    at module.exports._.memoize.Minimatch.nocase (C:\data\workspace\eclipse\my-nipr\node_modules\gulp-jshint\src\fileIgn
ored.js:38:7)
    at DestroyableTransform.<anonymous> (C:\data\workspace\eclipse\my-nipr\node_modules\gulp-jshint\src\extract.js:10:5)

    at DestroyableTransform._transform (C:\data\workspace\eclipse\my-nipr\node_modules\gulp-jshint\src\stream.js:26:15)
    at DestroyableTransform.Transform._read (C:\data\workspace\eclipse\my-nipr\node_modules\gulp-jshint\node_modules\rea
dable-stream\lib\_stream_transform.js:184:10)
    at DestroyableTransform.Transform._write (C:\data\workspace\eclipse\my-nipr\node_modules\gulp-jshint\node_modules\re
adable-stream\lib\_stream_transform.js:172:12)
    at doWrite (C:\data\workspace\eclipse\my-nipr\node_modules\gulp-jshint\node_modules\readable-stream\lib\_stream_writ
able.js:237:10)
    at writeOrBuffer (C:\data\workspace\eclipse\my-nipr\node_modules\gulp-jshint\node_modules\readable-stream\lib\_strea
m_writable.js:227:5)
    at DestroyableTransform.Writable.write (C:\data\workspace\eclipse\my-nipr\node_modules\gulp-jshint\node_modules\read
able-stream\lib\_stream_writable.js:194:11)
    at DestroyableTransform.ondata (C:\data\workspace\eclipse\my-nipr\node_modules\through2\node_modules\readable-stream
\lib\_stream_readable.js:531:20)
```