### PR TITLE
Update minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "gulp-util": "^3.0.0",
     "lodash": "^4.12.0",
-    "minimatch": "^2.0.1",
+    "minimatch": "^3.0.3",
     "rcloader": "0.1.2",
     "through2": "~0.6.1"
   },


### PR DESCRIPTION
avoids deprecation warnings during install.

#144 